### PR TITLE
Add the right property name for the corresponding h2database version

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -143,11 +143,11 @@
 		<property name="winmerge.dir" value="build/winmerge-${winmerge.version}-x64-exe"/>
 		<property name="h2v1.version" value="1.4.200"/>
 		<property name="h2v1.jar" value="h2-${h2v1.version}.jar"/>
-		<property name="h2v1.url" value="https://repo1.maven.org/maven2/com/h2database/h2/${h2.version}/${h2v1.jar}"/>
+		<property name="h2v1.url" value="https://repo1.maven.org/maven2/com/h2database/h2/${h2v1.version}/${h2v1.jar}"/>
 		<property name="h2v1.dir" value="${basedir}/build/h2"/>
 		<property name="h2v2.version" value="2.1.210"/>
 		<property name="h2v2.jar" value="h2-${h2v2.version}.jar"/>
-		<property name="h2v2.url" value="https://repo1.maven.org/maven2/com/h2database/h2/${h2.version}/${h2v2.jar}"/>
+		<property name="h2v2.url" value="https://repo1.maven.org/maven2/com/h2database/h2/${h2v2.version}/${h2v2.jar}"/>
 		<property name="h2v2.dir" value="${basedir}/build/h2/v2"/>
 		<property name="jms.version" value="1.1_spec-1.1"/>
 		<property name="jms.jar" value="geronimo-jms_${jms.version}.jar"/>


### PR DESCRIPTION
Fixes the error:

```console
get.h2v1:
Getting: https://repo1.maven.org/maven2/com/h2database/h2/${h2.version}/h2-1.4.200.jar
To: /home/sergi/Projects/frank-runner/download/h2-1.4.200.jar
Error opening connection java.io.FileNotFoundException: https://repo1.maven.org/maven2/com/h2database/h2/${h2.version}/h2-1.4.200.jar
Error opening connection java.io.FileNotFoundException: https://repo1.maven.org/maven2/com/h2database/h2/${h2.version}/h2-1.4.200.jar
Error opening connection java.io.FileNotFoundException: https://repo1.maven.org/maven2/com/h2database/h2/${h2.version}/h2-1.4.200.jar
Can't get https://repo1.maven.org/maven2/com/h2database/h2/${h2.version}/h2-1.4.200.jar to /home/sergi/Projects/frank-runner/download/h2-1.4.200.jar

BUILD FAILED
/home/sergi/Projects/frank-runner/build.xml:585: The following error occurred while executing this line:
/home/sergi/Projects/frank-runner/build.xml:567: The following error occurred while executing this line:
/home/sergi/Projects/frank-runner/build.xml:635: Can't get https://repo1.maven.org/maven2/com/h2database/h2/${h2.version}/h2-1.4.200.jar to /home/sergi/Projects/frank-runner/download/h2-1.4.200.jar
```